### PR TITLE
add safe_malloc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,23 +28,25 @@ SRCS	= src/main.c \
 OBJS	= $(SRCS:.c=.o)
 CC		= cc
 FLAGS	= -Wall -Wextra -Werror
-LIBS	= -lreadline -lhistory
-# FLAGS   += -fsanitize=address
-HEADDIR	= .
+LIBS	= -lreadline
+# FLAGS   += -fsanitize=address -g
+HEADDIR	= ./minishell.h
 LIBFT	= ./libft/libft.a
-# RLDIR   = $(shell brew --prefix readline)
+INCLUDES = -I$(RLDIR)/include -I$(HEADDIR)
+LIBDIRS  = -L$(RLDIR)/lib
+RLDIR   = $(shell brew --prefix readline)
 
 #################################################################
 
 %.o:%.c
-	$(CC) $(FLAGS) -I$(HEADDIR) -c $< -o $@
+	$(CC) $(FLAGS) $(INCLUDES) -c $< -o $@
 
 all: $(NAME)
 
 $(NAME): $(OBJS)
 	make -C ./libft
-	$(CC) $(FLAGS) $(HEADDER) $(OBJS) $(LIBFT) $(LIBS) -o $(NAME) 
-
+	$(CC) $(FLAGS) $(LIBDIRS) $(OBJS) $(LIBFT) $(LIBS) -o $(NAME) 
+	
 
 clean:
 	make fclean -C ./libft
@@ -62,9 +64,9 @@ test: all
 
 #################################################################
 
-# OS := $(shell uname -s)
+OS := $(shell uname -s)
 
-# ifeq ($(OS), Linus)
-# 	# commands for Linux
-# endif
+ifeq ($(OS), Linus)
+	# commands for Linux
+endif
 

--- a/libft/ft_calloc.c
+++ b/libft/ft_calloc.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_calloc.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yotsurud <yotsurud@student.42tokyo.>       +#+  +:+       +#+        */
+/*   By: tsururukakou <tsururukakou@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/16 12:07:31 by yotsurud          #+#    #+#             */
-/*   Updated: 2024/05/15 15:20:02 by yotsurud         ###   ########.fr       */
+/*   Updated: 2024/11/26 22:50:08 by tsururukako      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 

--- a/libft/ft_lstnew.c
+++ b/libft/ft_lstnew.c
@@ -6,7 +6,7 @@
 /*   By: tsururukakou <tsururukakou@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/19 16:12:49 by yotsurud          #+#    #+#             */
-/*   Updated: 2024/10/06 18:03:24 by tsururukako      ###   ########.fr       */
+/*   Updated: 2024/11/26 22:50:35 by tsururukako      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@ t_list	*ft_lstnew(void *content)
 {
 	t_list	*new;
 
-	new = (t_list *)malloc(sizeof(t_list));
+	new = (t_list *)safe_malloc(1, sizeof(t_list));
 	if (!new)
 		return (NULL);
 	new->content = content;

--- a/libft/ft_split.c
+++ b/libft/ft_split.c
@@ -6,7 +6,7 @@
 /*   By: tsururukakou <tsururukakou@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/16 18:54:06 by yotsurud          #+#    #+#             */
-/*   Updated: 2024/10/27 23:09:08 by tsururukako      ###   ########.fr       */
+/*   Updated: 2024/11/26 22:53:10 by tsururukako      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,9 +39,7 @@ static char	*ft_make_string_i(char const *s, char c)
 	len = 0;
 	while (s[len] && (s[len] != c))
 		len++;
-	str = (char *)ft_calloc((len + 1), sizeof(char));
-	if (!str)
-		return (NULL);
+	str = (char *)safe_malloc((len + 1), sizeof(char));
 	j = -1;
 	while (++j < len)
 		str[j] = s[j];
@@ -49,14 +47,14 @@ static char	*ft_make_string_i(char const *s, char c)
 	return (str);
 }
 
-static void	*ft_free_split(char **result, int i)
-{
-	while (result[i])
-		free(result[i--]);
-	if (result)
-		free(result);
-	return (NULL);
-}
+// static void	*ft_free_split(char **result, int i)
+// {
+// 	while (result[i])
+// 		free(result[i--]);
+// 	if (result)
+// 		free(result);
+// 	return (NULL);
+// }
 
 char	**ft_split(char const *s, char c)
 {
@@ -65,9 +63,7 @@ char	**ft_split(char const *s, char c)
 
 	if (!s)
 		return (NULL);
-	result = (char **)malloc(sizeof(char *) * (ft_count_i(s, c) + 1));
-	if (!result)
-		return (NULL);
+	result = (char **)safe_malloc(ft_count_i(s, c) + 1, sizeof(char *));
 	i = 0;
 	while (*s)
 	{
@@ -76,8 +72,6 @@ char	**ft_split(char const *s, char c)
 		if (*s && *s != c)
 		{
 			result[i] = ft_make_string_i(s, c);
-			if (!result[i])
-				return (ft_free_split(result, i), NULL);
 			i++;
 			while (*s && *s != c)
 				s++;

--- a/libft/ft_strdup.c
+++ b/libft/ft_strdup.c
@@ -3,14 +3,15 @@
 /*                                                        :::      ::::::::   */
 /*   ft_strdup.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hurabe <hurabe@student.42.fr>              +#+  +:+       +#+        */
+/*   By: tsururukakou <tsururukakou@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/16 13:21:43 by yotsurud          #+#    #+#             */
-/*   Updated: 2024/11/20 19:13:25 by hurabe           ###   ########.fr       */
+/*   Updated: 2024/11/26 22:55:45 by tsururukako      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
+#include "../minishell.h"
 
 char	*ft_strdup(const char *s1)
 {
@@ -22,9 +23,7 @@ char	*ft_strdup(const char *s1)
 		len = 0;
 	else
 		len = ft_strlen(s1);
-	ptr = (char *)malloc(sizeof(char) * (len + 1));
-	if (!ptr)
-		return (NULL);
+	ptr = (char *)safe_malloc(len + 1, sizeof(char));
 	i = 0;
 	while (i < len)
 	{

--- a/libft/ft_substr.c
+++ b/libft/ft_substr.c
@@ -3,14 +3,15 @@
 /*                                                        :::      ::::::::   */
 /*   ft_substr.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yotsurud <yotsurud@student.42tokyo.>       +#+  +:+       +#+        */
+/*   By: tsururukakou <tsururukakou@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/16 13:23:38 by yotsurud          #+#    #+#             */
-/*   Updated: 2024/04/20 20:27:05 by yotsurud         ###   ########.fr       */
+/*   Updated: 2024/11/26 23:23:05 by tsururukako      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
+#include "../minishell.h"
 
 char	*ft_substr(char const *s, unsigned int start, size_t len)
 {
@@ -25,9 +26,7 @@ char	*ft_substr(char const *s, unsigned int start, size_t len)
 		len = 0;
 	else if (start + len > ft_strlen(s))
 		len = ft_strlen(s) - start;
-	result = (char *)malloc(sizeof(char) * (len + 1));
-	if (!result)
-		return (NULL);
+	result = (char *)safe_malloc(len + 1, sizeof(char));
 	while (i < len && s[start + i])
 	{
 		result[i] = s[start + i];

--- a/libft/get_next_line.c
+++ b/libft/get_next_line.c
@@ -3,16 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   get_next_line.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yotsurud <yotsurud@student.42.fr>          +#+  +:+       +#+        */
+/*   By: tsururukakou <tsururukakou@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/02 12:46:06 by yotsurud          #+#    #+#             */
-/*   Updated: 2024/06/29 13:06:20 by yotsurud         ###   ########.fr       */
+/*   Updated: 2024/11/26 22:59:08 by tsururukako      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "get_next_line.h"
+#include "../minishell.h"
 
-static char	*ft_strjoin(char *s1, char c, int len)
+static char	*ft_strjoin_gnl(char *s1, char c, int len)
 {
 	char	*string;
 	int		i;
@@ -21,9 +22,7 @@ static char	*ft_strjoin(char *s1, char c, int len)
 	if (!s1 && !c)
 		return (NULL);
 	string = NULL;
-	string = (char *)malloc(sizeof(char) * len);
-	if (!string)
-		return (free(s1), NULL);
+	string = (char *)safe_malloc(len, sizeof(char));
 	i = -1;
 	while (++i < len - 2)
 		string[i] = s1[i];
@@ -81,7 +80,7 @@ char	*get_next_line(int fd)
 			return (free(result), NULL);
 		if (c == EOF)
 			break ;
-		result = ft_strjoin(result, c, len);
+		result = ft_strjoin_gnl(result, c, len);
 		len++;
 		if (c == '\n')
 			break ;

--- a/minishell.h
+++ b/minishell.h
@@ -6,7 +6,7 @@
 /*   By: tsururukakou <tsururukakou@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/05 06:29:52 by yotsurud          #+#    #+#             */
-/*   Updated: 2024/11/26 01:30:28 by tsururukako      ###   ########.fr       */
+/*   Updated: 2024/11/26 22:42:15 by tsururukako      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -112,6 +112,8 @@ typedef struct s_cmd
 	char			**cmd;
 	char			**path;
 	char			*err_msg;
+	char			*err_file;
+	int				err_no;
 	struct s_token	*token;
 	t_kind			status;
 	int				flag;
@@ -210,6 +212,7 @@ void	free_cmd(t_cmd *cmd);
 // utils
 char	*strjoin_with_free(char *s1, char *s2, int select);
 size_t	strchr_len(const char *s, int c);
+void	*safe_malloc(size_t count, size_t size);
 
 // signal
 void	reset_signal(int signum);

--- a/src/builtin_cd.c
+++ b/src/builtin_cd.c
@@ -6,7 +6,7 @@
 /*   By: tsururukakou <tsururukakou@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 10:15:09 by yotsurud          #+#    #+#             */
-/*   Updated: 2024/11/25 23:45:05 by tsururukako      ###   ########.fr       */
+/*   Updated: 2024/11/26 23:03:06 by tsururukako      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,7 @@
 static void	update_env_var(t_env *env, char *key, char *value)
 {
     t_env *current = env;
+    t_env *new_node;
 
     while (current)
     {
@@ -26,11 +27,8 @@ static void	update_env_var(t_env *env, char *key, char *value)
         }
         current = current->next;
     }
-
     // 存在しない場合、新しいノードを追加
-    t_env *new_node = malloc(sizeof(t_env));
-    if (!new_node)
-        return;
+	new_node = (t_env *)safe_malloc(1, sizeof(t_env));
     new_node->key = ft_strdup(key);
     new_node->value = ft_strdup(value);
     new_node->next = NULL;

--- a/src/command.c
+++ b/src/command.c
@@ -6,7 +6,7 @@
 /*   By: tsururukakou <tsururukakou@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 10:49:39 by yotsurud          #+#    #+#             */
-/*   Updated: 2024/11/26 00:51:07 by tsururukako      ###   ########.fr       */
+/*   Updated: 2024/11/26 23:13:24 by tsururukako      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,18 +24,13 @@ bool	set_err_message(t_cmd *cmd, char *str, char *err_str)
 	else
 	{
 		cmd->err_msg = strjoin_with_free("bash: ", str, NO_FREE);
-		if (cmd->err_msg)
-			cmd->err_msg = strjoin_with_free(cmd->err_msg,
-					": ", FREE_S1);
+		cmd->err_msg = strjoin_with_free(cmd->err_msg, ": ", FREE_S1);
 		if (cmd->err_msg && (cmd->cmd[0][0] == '.' || cmd->cmd[0][0] == '/'))
 			cmd->err_msg = strjoin_with_free(cmd->err_msg, err_str, FREE_S1);
 		else if (cmd->err_msg)
 			cmd->err_msg = strjoin_with_free(cmd->err_msg, "command not found", FREE_S1);
-		if (cmd->err_msg)
-			cmd->err_msg = strjoin_with_free(cmd->err_msg, "\n", FREE_S1);
+		cmd->err_msg = strjoin_with_free(cmd->err_msg, "\n", FREE_S1);
 	}
-	if (!cmd->err_msg)
-		exit((ft_printf(2, "malloc: %s\n", strerror(errno)), EXIT_FAILURE));
 	return (true);
 }
 
@@ -72,19 +67,13 @@ static t_cmd	*make_command_array(t_token *token, t_cmd *cmd)
 
 	array_count = count_array(token);
 	token_count = count_token(token);
-	cmd->cmd = (char **)malloc(sizeof(char *) * (array_count + 1));
-	if (!(cmd->cmd))
-		exit((ft_printf(2, "malloc: %s\n", strerror(errno)), EXIT_FAILURE));
+	cmd->cmd = (char **)safe_malloc(array_count + 1, sizeof(char *));
 	i = -1;
 	j = -1;
 	while (++i < token_count)
 	{
 		if (token->kind == BUILTIN || token->kind == COMMAND || token->kind == OPTION)
-		{
 			cmd->cmd[++j] = ft_strdup(token->word);
-			if (!cmd->cmd[j])
-				exit((ft_printf(2, "malloc: %s\n", strerror(errno)), EXIT_FAILURE));
-		}
 		token = token->next;
 	}
 	cmd->cmd[array_count] = NULL;
@@ -113,25 +102,15 @@ static bool	make_path_cmd(t_token *token, t_cmd *cmd)
 
 t_cmd	*command_return(t_cmd *cmd, t_token *token)
 {
-	if (cmd->pathname && access(cmd->pathname, X_OK) != 0
-		&& !set_err_message(cmd, cmd->cmd[0], strerror(errno)))
-	return (NULL);
+	if (cmd->pathname && access(cmd->pathname, X_OK) != 0)
+		set_err_message(cmd, cmd->cmd[0], strerror(errno));
 	cmd->token = token;
-	return (cmd);
-}
-
-t_cmd	*malloc_command(t_cmd *cmd)
-{
-	cmd = NULL;
-	cmd = (t_cmd *)malloc(sizeof (t_cmd));
-	if (!cmd)
-		exit((ft_printf(2, "malloc: %s\n", strerror(errno)), EXIT_FAILURE));
 	return (cmd);
 }
 
 t_cmd	*make_cmd(t_token *token, t_cmd *cmd, int command_flag)
 {
-	cmd = malloc_command(cmd);
+	cmd = (t_cmd *)safe_malloc(1, sizeof(t_cmd));
 	init_cmd(cmd);
 	while (token)
 	{

--- a/src/command_utils.c
+++ b/src/command_utils.c
@@ -6,7 +6,7 @@
 /*   By: tsururukakou <tsururukakou@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/05 06:27:24 by yotsurud          #+#    #+#             */
-/*   Updated: 2024/11/25 23:43:18 by tsururukako      ###   ########.fr       */
+/*   Updated: 2024/11/26 23:04:56 by tsururukako      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,12 +23,10 @@ bool	init_cmd(t_cmd *cmd)
 	cmd->cmd = NULL;
 	cmd->path = NULL;
 	if (getenv_str("PATH"))
-	{
 		cmd->path = ft_split(getenv_str("PATH"), ':');
-		if (!cmd->path)
-			exit((ft_printf(2, "malloc: %s\n", strerror(errno)), EXIT_FAILURE));
-	}
 	cmd->err_msg = NULL;
+	cmd->err_file = NULL;
+	cmd->err_no = -1;
 	cmd->token = NULL;
 	cmd->status = -1;
 	cmd->flag = 0;
@@ -81,10 +79,7 @@ char	*make_pwd_path(char *command, char *pwd)
 		return (strjoin_with_free("", command, NO_FREE));//不要?
 	str = NULL;
 	str = strjoin_with_free(pwd, "/", NO_FREE);
-	if (str)
-		str = strjoin_with_free(str, command, FREE_S1);
-	// if (!str)
-	// 	exit((ft_printf(2, "malloc: %s\n", strerror(errno)), EXIT_FAILURE));
+	str = strjoin_with_free(str, command, FREE_S1);
 	return (str);
 }
 

--- a/src/make_env.c
+++ b/src/make_env.c
@@ -6,7 +6,7 @@
 /*   By: tsururukakou <tsururukakou@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/05 06:29:09 by yotsurud          #+#    #+#             */
-/*   Updated: 2024/11/25 23:05:04 by tsururukako      ###   ########.fr       */
+/*   Updated: 2024/11/26 23:20:09 by tsururukako      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,11 +31,6 @@ static t_env	*change_last_node(t_env *env)
 	tmp = env->value;
 	env->value = ft_strdup("/usr/bin/env");
 	free(tmp);
-	if (!env->value)
-	{
-		ft_printf(2, "bash: malloc: %s\n", strerror(errno));
-		return (free_env(set_env(GET, NULL)), NULL);
-	}
 	return (ptr);
 }
 
@@ -60,18 +55,12 @@ static int	lstnew(t_env **start, char *env)
 	t_env	*new;
 	int		len;
 
-	new = (t_env *)malloc(sizeof(t_env));
-	if (!new)
-		return (FALSE);
+	new = (t_env *)safe_malloc(1, sizeof(t_env));
 	len = 0;
 	len = strchr_len(env, '=');
-	new->key = (char *)malloc((len + 1) * sizeof(char));
-	if (!new->key)
-		return (free(new), FALSE);
+	new->key = (char *)safe_malloc(len + 1, sizeof(char));
 	ft_strlcpy(new->key, env, len + 1);
 	new->value = ft_strdup((ft_strchr(env, '=') + 1));
-	if (!new->value)
-		return (free(new->key), free(new), FALSE);
 	new->next = NULL;
 	lstadd_back(start, new);
 	return (TRUE);

--- a/src/process.c
+++ b/src/process.c
@@ -6,7 +6,7 @@
 /*   By: tsururukakou <tsururukakou@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 10:50:40 by yotsurud          #+#    #+#             */
-/*   Updated: 2024/11/26 01:41:43 by tsururukako      ###   ########.fr       */
+/*   Updated: 2024/11/26 23:26:48 by tsururukako      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -79,7 +79,6 @@ static void	child_process(t_cmd *cmd, int stdio[2])
 		exit((do_builtin(cmd), end_status(GET, 0)));
 	if (!(cmd->cmd) || cmd->status == SYNTAX)
 		exit(EXIT_SUCCESS);
-	write(2, "here\n", 5);
 	if (execve(cmd->pathname, cmd->cmd, NULL) == -1)
 	{
 		exit(EXIT_FAILURE);

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   tokenizer.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hurabe <hurabe@student.42.fr>              +#+  +:+       +#+        */
+/*   By: tsururukakou <tsururukakou@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/19 19:28:45 by hurabe            #+#    #+#             */
-/*   Updated: 2024/11/23 20:00:43 by hurabe           ###   ########.fr       */
+/*   Updated: 2024/11/26 23:24:20 by tsururukako      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -81,13 +81,7 @@ static t_token *append_token(t_token **head, t_token **current, char *content, t
 {
 	t_token	*new_token;
 
-	new_token = (t_token *)malloc(sizeof(t_token));
-	if (!new_token)
-	{
-		perror("malloc");
-		free_token(*head);
-		return (NULL);
-	}
+	new_token = (t_token *)safe_malloc(1, sizeof(t_token));
 	new_token->word = content;
 	new_token->kind = kind;
 	new_token->is_quoted = is_quoted;
@@ -138,25 +132,27 @@ static t_token *create_dollar_token(char **input)
 	(*input)--;
     // 環境変数名を抽出
     env_key = ft_substr(*input, 0, len + 1);
-    if (!env_key)
-    {
-        end_status(SET, EXIT_FAILURE);
-        perror("[DEBUG] Error: malloc failed while extracting env_key");
-        return (NULL);
-    }
+    // if (!env_key)
+    // {
+    //     end_status(SET, EXIT_FAILURE);
+    //     perror("[DEBUG] Error: malloc failed while extracting env_key");
+    //     return (NULL);
+    // }
 
     // 入力ポインタを環境変数名の長さ分進める
     *input += len + 1;
 
     // 新しいトークンを作成
-    t_token *dollar_token = (t_token *)malloc(sizeof(t_token));
-    if (!dollar_token)
-    {
-        end_status(SET, EXIT_FAILURE);
-        free(env_key);
-        perror("[DEBUG] Error: malloc failed while creating dollar_token");
-        return (NULL);
-    }
+    t_token *dollar_token;
+    
+    dollar_token = (t_token *)safe_malloc(1, sizeof(t_token));
+    // if (!dollar_token)
+    // {
+    //     end_status(SET, EXIT_FAILURE);
+    //     free(env_key);
+    //     perror("[DEBUG] Error: malloc failed while creating dollar_token");
+    //     return (NULL);
+    // }
 
 	dollar_token->word = env_key;
 	dollar_token->kind = OPTION;

--- a/src/tokenizer_utils.c
+++ b/src/tokenizer_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   tokenizer_utils.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hurabe <hurabe@student.42.fr>              +#+  +:+       +#+        */
+/*   By: tsururukakou <tsururukakou@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/19 19:41:10 by hurabe            #+#    #+#             */
-/*   Updated: 2024/11/19 19:41:13 by hurabe           ###   ########.fr       */
+/*   Updated: 2024/11/26 23:18:03 by tsururukako      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,9 +20,7 @@ char	*ft_strjoin_one(char *str, char c)
 	len = 0;
 	if (str)
 		len = ft_strlen(str);
-	new_str = (char *)malloc(len + 2);
-	if (!new_str)
-		return (NULL);
+	new_str = (char *)safe_malloc(len + 2, sizeof(char));
 	if (str)
 	{
 		ft_strcpy(new_str, str);

--- a/src/utils.c
+++ b/src/utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   utils.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yotsurud <yotsurud@student.42.fr>          #+#  +:+       +#+        */
+/*   By: tsururukakou <tsururukakou@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024-11-05 06:29:40 by yotsurud          #+#    #+#             */
-/*   Updated: 2024/11/05 17:50:45 by yotsurud         ###   ########.fr       */
+/*   Created: 2024/11/05 06:29:40 by yotsurud          #+#    #+#             */
+/*   Updated: 2024/11/26 22:48:23 by tsururukako      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,12 +23,10 @@ char	*strjoin_with_free(char *s1, char *s2, int select)
 	i = -1;
 	j = -1;
 	if (!(*s1))
-		result = (char *)malloc(sizeof(char) * (ft_strlen(s2) + 1));
+		result = (char *)safe_malloc(ft_strlen(s2) + 1, sizeof(char));
 	else
-		result = (char *)malloc(sizeof(char) * (ft_strlen(s1)
-					+ ft_strlen(s2) + 1));
-	if (!result)
-		exit((ft_printf(2, "malloc: %s\n", strerror(errno)), EXIT_FAILURE));
+		result = (char *)safe_malloc(ft_strlen(s1) + ft_strlen(s2) + 1
+				, sizeof(char));
 	while (s1[++i])
 		result[i] = s1[i];
 	while (s2[++j])
@@ -57,4 +55,14 @@ size_t	strchr_len(const char *s, int c)
 		return (i);
 	else
 		return (0);
+}
+
+void	*safe_malloc(size_t count, size_t size)
+{
+	void	*tmp;
+	
+	tmp = ft_calloc(size, count);
+	if (!tmp)
+		exit((ft_printf(2, "malloc: %s\n", strerror(errno)), EXIT_FAILURE));
+	return (tmp);
 }


### PR DESCRIPTION
mallocに失敗した時にエラーメッセージを出力してminishellをexitする関数(safe_malloc)を実装
safe_mallocでmallocをした場合はエラー処理が不要になる